### PR TITLE
Add snapshot url

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ This will start the server with the following default configuration:
 * Port: 8080
 * Resolution: 640x480
 * Framerate: 15fps
+* Stream URL: /stream
+* Snapshot URL: /snapshot
 
 ## Configuration
 
@@ -41,22 +43,24 @@ On startup the following arguments are supported:
 | `-p`, `--port`           | Port where the server will listen for new incoming connections.                                     | `8080`       |
 | `-r`, `--resolution`     | Resolution of the captured frames. This argument expects the format <width>x<height>                | `640x480`    |
 | `-f`, `--fps`            | Framerate in frames per second (fps).                                                               | `15`         |
+| `-st`, `--stream_url`    | Sets the URL for the mjpeg stream.                                                                  | `/stream`    |
+| `-sn`, `--snapshot_url`  | Sets the URL for snapshots (single frame of stream).                                                | `/snapshot`  |
 | `-af`, `--autofocus`     | Autofocus mode. Supported modes: `manual`, `continous`                                              | `continuous` |
 | `-l`, `--lensposition`   | Set focal distance. 0 for infinite focus, 0.5 for approximate 50cm. Only used with Autofocus manual | `0.0`        |
 | `-s`, `--autofocusspeed` | Autofocus speed. Supported values: `normal`, `fast`. Only used with Autofocus continuous            | `normal`     |
 
 Starting the server without any argument is the same as
 ```shell
-./run.py -b 0.0.0.0 -p 8080 -r 640x480 -f 15
+./run.py -b 0.0.0.0 -p 8080 -r 640x480 -f 15 -st \'/stream\' -sn \'/snapshot\' -af continous -l 0.0 -s normal
 ```
 
-The stream can then be accessed at `http://<IP of the server>:8080/stream.mjpeg`
+The stream can then be accessed at `http://<IP of the server>:8080/stream`
 
 ## Using Spyglass with Mainsail
 
 If you ant to use Spyglass as a webcam source for [Mainsail]() add a webcam with the following configuration:
-* URL Stream: `/webcam/stream.mjpg`
-* URL Snapshot: `/webcam/stream.mjpg`
+* URL Stream: `/webcam/stream`
+* URL Snapshot: `/webcam/snapshot`
 * Service: `V4L-MJPEG`
 
 ## Install as application

--- a/spyglass/cli.py
+++ b/spyglass/cli.py
@@ -28,6 +28,8 @@ def main(args=None):
     bind_address = parsed_args.bindaddress
     port = parsed_args.port
     width, height = split_resolution(parsed_args.resolution)
+    stream_url = parsed_args.stream_url
+    snapshot_url = parsed_args.snapshot_url
     picam2 = init_camera(
         width,
         height,
@@ -40,7 +42,7 @@ def main(args=None):
     picam2.start_recording(JpegEncoder(), FileOutput(output))
 
     try:
-        run_server(bind_address, port, output)
+        run_server(bind_address, port, output, stream_url, snapshot_url)
     finally:
         picam2.stop_recording()
 
@@ -101,6 +103,10 @@ def get_parser():
     parser.add_argument('-r', '--resolution', type=resolution_type, default='640x480',
                         help='Resolution of the images width x height')
     parser.add_argument('-f', '--fps', type=int, default=15, help='Frames per second to capture')
+    parser.add_argument('-st', '--stream_url', type=str, default='/stream',
+                        help='Sets the URL for the mpjpeg stream')
+    parser.add_argument('-sn', '--snapshot_url', type=str, default='/snapshot',
+                        help='Sets the URL for snapshots (single frame of stream)')
     parser.add_argument('-af', '--autofocus', type=str, default='continuous', choices=['manual', 'continuous'],
                         help='Autofocus mode')
     parser.add_argument('-l', '--lensposition', type=float, default=0.0,

--- a/spyglass/cli.py
+++ b/spyglass/cli.py
@@ -104,7 +104,7 @@ def get_parser():
                         help='Resolution of the images width x height')
     parser.add_argument('-f', '--fps', type=int, default=15, help='Frames per second to capture')
     parser.add_argument('-st', '--stream_url', type=str, default='/stream',
-                        help='Sets the URL for the mpjpeg stream')
+                        help='Sets the URL for the mjpeg stream')
     parser.add_argument('-sn', '--snapshot_url', type=str, default='/snapshot',
                         help='Sets the URL for snapshots (single frame of stream)')
     parser.add_argument('-af', '--autofocus', type=str, default='continuous', choices=['manual', 'continuous'],

--- a/spyglass/server.py
+++ b/spyglass/server.py
@@ -24,42 +24,36 @@ class StreamingServer(socketserver.ThreadingMixIn, server.HTTPServer):
     daemon_threads = True
 
 
-def run_server(bind_address, port, output):
-    class StreamingHandler(server.BaseHTTPRequestHandler):
-        stream_url = '/stream'
-        snapshot_url = '/snapshot'
-        
+def run_server(bind_address, port, output, stream_url='/stream', snapshot_url='/snapshot'):
+    class StreamingHandler(server.BaseHTTPRequestHandler):        
         def do_GET(self):
             if self.path in [self.stream_url, self.snapshot_url]:
-                self.startStream(self.path)
+                self.send_response(200)
+                self.send_header('Age', 0)
+                self.send_header('Cache-Control', 'no-cache, private')
+                self.send_header('Pragma', 'no-cache')
+                self.send_header('Content-Type', 'multipart/x-mixed-replace; boundary=FRAME')
+                self.end_headers()
+                try:
+                    while True:
+                        with output.condition:
+                            output.condition.wait()
+                            frame = output.frame
+                        self.wfile.write(b'--FRAME\r\n')
+                        self.send_header('Content-Type', 'image/jpeg')
+                        self.send_header('Content-Length', len(frame))
+                        self.end_headers()
+                        self.wfile.write(frame)
+                        self.wfile.write(b'\r\n')
+                        if self.path == self.snapshot_url:
+                            return
+                except Exception as e:
+                    logging.warning(
+                        'Removed streaming client %s: %s',
+                        self.client_address, str(e))
             else:
                 self.send_error(404)
                 self.end_headers()
-
-        def startStream(self, url):            
-            self.send_response(200)
-            self.send_header('Age', 0)
-            self.send_header('Cache-Control', 'no-cache, private')
-            self.send_header('Pragma', 'no-cache')
-            self.send_header('Content-Type', 'multipart/x-mixed-replace; boundary=FRAME')
-            self.end_headers()
-            try:
-                while True:
-                    with output.condition:
-                        output.condition.wait()
-                        frame = output.frame
-                    self.wfile.write(b'--FRAME\r\n')
-                    self.send_header('Content-Type', 'image/jpeg')
-                    self.send_header('Content-Length', len(frame))
-                    self.end_headers()
-                    self.wfile.write(frame)
-                    self.wfile.write(b'\r\n')
-                    if url == self.snapshot_url:
-                        return
-            except Exception as e:
-                logging.warning(
-                    'Removed streaming client %s: %s',
-                    self.client_address, str(e))
 
     logger.info("Server listening on http://%s:%d/stream", bind_address, port)
     address = (bind_address, port)

--- a/spyglass/server.py
+++ b/spyglass/server.py
@@ -26,8 +26,8 @@ class StreamingServer(socketserver.ThreadingMixIn, server.HTTPServer):
 
 def run_server(bind_address, port, output):
     class StreamingHandler(server.BaseHTTPRequestHandler):
-        streamURL = '/stream'
-        snapshotURL = '/snapshot'
+        stream_url = '/stream'
+        snapshot_url = '/snapshot'
         
         def do_GET(self):
             if self.path in [self.streamURL, self.snapshotURL]:

--- a/spyglass/server.py
+++ b/spyglass/server.py
@@ -30,7 +30,7 @@ def run_server(bind_address, port, output):
         snapshot_url = '/snapshot'
         
         def do_GET(self):
-            if self.path in [self.streamURL, self.snapshotURL]:
+            if self.path in [self.stream_url, self.snapshot_url]:
                 self.startStream(self.path)
             else:
                 self.send_error(404)
@@ -54,7 +54,7 @@ def run_server(bind_address, port, output):
                     self.end_headers()
                     self.wfile.write(frame)
                     self.wfile.write(b'\r\n')
-                    if url == self.snapshotURL:
+                    if url == self.snapshot_url:
                         return
             except Exception as e:
                 logging.warning(

--- a/spyglass/server.py
+++ b/spyglass/server.py
@@ -27,7 +27,7 @@ class StreamingServer(socketserver.ThreadingMixIn, server.HTTPServer):
 def run_server(bind_address, port, output, stream_url='/stream', snapshot_url='/snapshot'):
     class StreamingHandler(server.BaseHTTPRequestHandler):        
         def do_GET(self):
-            if self.path in [self.stream_url, self.snapshot_url]:
+            if self.path in [stream_url, snapshot_url]:
                 self.send_response(200)
                 self.send_header('Age', 0)
                 self.send_header('Cache-Control', 'no-cache, private')
@@ -45,7 +45,7 @@ def run_server(bind_address, port, output, stream_url='/stream', snapshot_url='/
                         self.end_headers()
                         self.wfile.write(frame)
                         self.wfile.write(b'\r\n')
-                        if self.path == self.snapshot_url:
+                        if self.path == snapshot_url:
                             return
                 except Exception as e:
                     logging.warning(

--- a/spyglass/server.py
+++ b/spyglass/server.py
@@ -27,35 +27,59 @@ class StreamingServer(socketserver.ThreadingMixIn, server.HTTPServer):
 def run_server(bind_address, port, output, stream_url='/stream', snapshot_url='/snapshot'):
     class StreamingHandler(server.BaseHTTPRequestHandler):        
         def do_GET(self):
-            if self.path in [stream_url, snapshot_url]:
-                self.send_response(200)
-                self.send_header('Age', 0)
-                self.send_header('Cache-Control', 'no-cache, private')
-                self.send_header('Pragma', 'no-cache')
-                self.send_header('Content-Type', 'multipart/x-mixed-replace; boundary=FRAME')
-                self.end_headers()
-                try:
-                    while True:
-                        with output.condition:
-                            output.condition.wait()
-                            frame = output.frame
-                        self.wfile.write(b'--FRAME\r\n')
-                        self.send_header('Content-Type', 'image/jpeg')
-                        self.send_header('Content-Length', len(frame))
-                        self.end_headers()
-                        self.wfile.write(frame)
-                        self.wfile.write(b'\r\n')
-                        if self.path == snapshot_url:
-                            return
-                except Exception as e:
-                    logging.warning(
-                        'Removed streaming client %s: %s',
-                        self.client_address, str(e))
+            if self.path == stream_url:
+                self.start_streaming()
+            elif self.path == snapshot_url:
+                self.send_snapshot()
             else:
                 self.send_error(404)
                 self.end_headers()
 
-    logger.info("Server listening on http://%s:%d/stream", bind_address, port)
+        def start_streaming(self):
+            try:
+                self.send_response(200)
+                self.send_default_headers()
+                self.send_header('Content-Type', 'multipart/x-mixed-replace; boundary=FRAME')
+                self.end_headers()
+                while True:
+                    with output.condition:
+                        output.condition.wait()
+                        frame = output.frame
+                    self.wfile.write(b'--FRAME\r\n')
+                    self.send_jpeg_content_headers(frame)
+                    self.end_headers()
+                    self.wfile.write(frame)
+                    self.wfile.write(b'\r\n')
+            except Exception as e:
+                logging.warning('Removed streaming client %s: %s', self.client_address, str(e))
+
+        def send_snapshot(self):
+            try:
+                self.send_response(200)
+                self.send_default_headers()
+                with output.condition:
+                    output.condition.wait()
+                    frame = output.frame
+                self.send_jpeg_content_headers(frame)
+                self.end_headers()
+                self.wfile.write(frame)
+            except Exception as e:
+                logging.warning(
+                    'Removed client %s: %s',
+                    self.client_address, str(e))
+
+        def send_default_headers(self):
+            self.send_header('Age', 0)
+            self.send_header('Cache-Control', 'no-cache, private')
+            self.send_header('Pragma', 'no-cache')
+
+        def send_jpeg_content_headers(self, frame):
+            self.send_header('Content-Type', 'image/jpeg')
+            self.send_header('Content-Length', len(frame))
+
+    logger.info('Server listening on %s:%d', bind_address, port)
+    logger.info('Streaming endpoint: %s', stream_url)
+    logger.info('Snapshot endpoint: %s', snapshot_url)
     address = (bind_address, port)
     current_server = StreamingServer(address, StreamingHandler)
     current_server.serve_forever()

--- a/spyglass/server.py
+++ b/spyglass/server.py
@@ -26,34 +26,42 @@ class StreamingServer(socketserver.ThreadingMixIn, server.HTTPServer):
 
 def run_server(bind_address, port, output):
     class StreamingHandler(server.BaseHTTPRequestHandler):
+        streamURL = '/stream'
+        snapshotURL = '/snapshot'
+        
         def do_GET(self):
-            if self.path == '/stream.mjpg':
-                self.send_response(200)
-                self.send_header('Age', 0)
-                self.send_header('Cache-Control', 'no-cache, private')
-                self.send_header('Pragma', 'no-cache')
-                self.send_header('Content-Type', 'multipart/x-mixed-replace; boundary=FRAME')
-                self.end_headers()
-                try:
-                    while True:
-                        with output.condition:
-                            output.condition.wait()
-                            frame = output.frame
-                        self.wfile.write(b'--FRAME\r\n')
-                        self.send_header('Content-Type', 'image/jpeg')
-                        self.send_header('Content-Length', len(frame))
-                        self.end_headers()
-                        self.wfile.write(frame)
-                        self.wfile.write(b'\r\n')
-                except Exception as e:
-                    logging.warning(
-                        'Removed streaming client %s: %s',
-                        self.client_address, str(e))
+            if self.path in [self.streamURL, self.snapshotURL]:
+                self.startStream(self.path)
             else:
                 self.send_error(404)
                 self.end_headers()
 
-    logger.info("Server listening on http://%s:%d/stream.mjpg", bind_address, port)
+        def startStream(self, url):            
+            self.send_response(200)
+            self.send_header('Age', 0)
+            self.send_header('Cache-Control', 'no-cache, private')
+            self.send_header('Pragma', 'no-cache')
+            self.send_header('Content-Type', 'multipart/x-mixed-replace; boundary=FRAME')
+            self.end_headers()
+            try:
+                while True:
+                    with output.condition:
+                        output.condition.wait()
+                        frame = output.frame
+                    self.wfile.write(b'--FRAME\r\n')
+                    self.send_header('Content-Type', 'image/jpeg')
+                    self.send_header('Content-Length', len(frame))
+                    self.end_headers()
+                    self.wfile.write(frame)
+                    self.wfile.write(b'\r\n')
+                    if url == self.snapshotURL:
+                        return
+            except Exception as e:
+                logging.warning(
+                    'Removed streaming client %s: %s',
+                    self.client_address, str(e))
+
+    logger.info("Server listening on http://%s:%d/stream", bind_address, port)
     address = (bind_address, port)
     current_server = StreamingServer(address, StreamingHandler)
     current_server.serve_forever()


### PR DESCRIPTION
- Added `http://<your-ip>:<port>/snapshot` returning the current single frame of the stream.
- Shorted `http://<your-ip>:<port>/stream.mjpg` to `http://<your-ip>:<port>/stream`
- Added `startStream` method into `StreamingHandler` to avoid duplication of code
- `startStream` returns after the first frame of the stream to show only a single frame