### PR TITLE
docs: Add ADR about used encoder

### DIFF
--- a/docs/adr/001_encoder.md
+++ b/docs/adr/001_encoder.md
@@ -27,7 +27,7 @@ The Picamera2 library contains different encoders to capture video.
 We want to provide an mjpeg video stream and single still images (snapshots).
 
 This software aims at systems that will run additional tasks like 3D printers running Klipper,
-Mainsail etc. In addition we assume that only few clients will access the stream simultaneously.
+Mainsail etc.
 
 ## Options
 
@@ -40,8 +40,8 @@ We will use the `MJPEGEncoder` that is using the Raspberry Pi's hardware.
 
 ## Consequences
 
-* Following the documentation this encoder will consume less CPU than the software encoder
-* Too many simultaneous streams will put more load on the CPU than the software encoder.
+* Following the documentation and some experiments this encoder will consume less CPU than the software encoder.
+* This encoder is only available on Raspberry Pi hardware
 
 ## Useful information
 

--- a/docs/adr/001_encoder.md
+++ b/docs/adr/001_encoder.md
@@ -1,0 +1,48 @@
+# 001 - Encoder used for Capturing Video
+
+## Date
+
+2023-01-26
+
+## Status
+
+Decision
+
+## Category
+
+Architecture
+
+## Authors
+
+@roamingthings, @mryel00
+
+## References
+
+[The Picamera2 Library Documentation](https://datasheets.raspberrypi.com/camera/picamera2-manual.pdf)
+
+## Context
+
+The Picamera2 library contains different encoders to capture video.
+
+We want to provide an mjpeg video stream and single still images (snapshots).
+
+This software aims at systems that will run additional tasks like 3D printers running Klipper,
+Mainsail etc. In addition we assume that only few clients will access the stream simultaneously.
+
+## Options
+
+1. Use `JpegEncoder` a multi-threaded software JPEG encoder
+2. Use `MJPEGEncoder` an MJPEG encoder using the Raspberry Pi’s hardware
+
+## Decision
+
+We will use the `MJPEGEncoder` that is using the Raspberry Pi's hardware.
+
+## Consequences
+
+* Following the documentation this encoder will consume less CPU than the software encoder
+* Too many simultaneous streams will put more load on the CPU than the software encoder.
+
+## Useful information
+
+--


### PR DESCRIPTION
We will use Architecture Decision Records (ADR) for documenting decisions regarding the further development.