### PR TITLE
feat: Restrict resolution to 1920x1920

### DIFF
--- a/spyglass/cli.py
+++ b/spyglass/cli.py
@@ -12,6 +12,8 @@ from spyglass.server import run_server
 from picamera2.encoders import MJPEGEncoder
 from picamera2.outputs import FileOutput
 
+MAX_WIDTH = 1920
+MAX_HEIGHT= 1920
 
 def main(args=None):
     """Entry point for hello cli.
@@ -79,6 +81,8 @@ def split_resolution(res):
     parts = res.split('x')
     w = int(parts[0])
     h = int(parts[1])
+    if w > MAX_WIDTH or h > MAX_HEIGHT:
+        raise argparse.ArgumentTypeError("Maximum supported resolution is 1920x1920")
     return w, h
 
 
@@ -104,7 +108,7 @@ def get_parser():
                                                                                  'connections')
     parser.add_argument('-p', '--port', type=int, default=8080, help='Bind to port for incoming connections')
     parser.add_argument('-r', '--resolution', type=resolution_type, default='640x480',
-                        help='Resolution of the images width x height')
+                        help='Resolution of the images width x height. Maximum is 1920x1920.')
     parser.add_argument('-f', '--fps', type=int, default=15, help='Frames per second to capture')
     parser.add_argument('-st', '--stream_url', type=str, default='/stream',
                         help='Sets the URL for the mjpeg stream')
@@ -117,11 +121,11 @@ def get_parser():
                              'Only used with Autofocus manual')
     parser.add_argument('-s', '--autofocusspeed', type=str, default='normal', choices=['normal', 'fast'],
                         help='Autofocus speed. Only used with Autofocus continuous')
-    parser.add_argument('-ud', '--upsidedown', action='store_true', 
+    parser.add_argument('-ud', '--upsidedown', action='store_true',
                         help='Rotate the immage by 180°')
-    parser.add_argument('-fh', '--flip_horizontal', action='store_true', 
+    parser.add_argument('-fh', '--flip_horizontal', action='store_true',
                         help='Mirror the image horizontally')
-    parser.add_argument('-fv', '--flip_vertical', action='store_true', 
+    parser.add_argument('-fv', '--flip_vertical', action='store_true',
                         help='Mirror the image vertically')
     return parser
 

--- a/spyglass/cli.py
+++ b/spyglass/cli.py
@@ -13,7 +13,7 @@ from picamera2.encoders import MJPEGEncoder
 from picamera2.outputs import FileOutput
 
 MAX_WIDTH = 1920
-MAX_HEIGHT= 1920
+MAX_HEIGHT = 1920
 
 def main(args=None):
     """Entry point for hello cli.
@@ -122,7 +122,7 @@ def get_parser():
     parser.add_argument('-s', '--autofocusspeed', type=str, default='normal', choices=['normal', 'fast'],
                         help='Autofocus speed. Only used with Autofocus continuous')
     parser.add_argument('-ud', '--upsidedown', action='store_true',
-                        help='Rotate the immage by 180°')
+                        help='Rotate the image by 180°')
     parser.add_argument('-fh', '--flip_horizontal', action='store_true',
                         help='Mirror the image horizontally')
     parser.add_argument('-fv', '--flip_vertical', action='store_true',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import argparse
 import pytest
 from unittest.mock import MagicMock, ANY
 
@@ -96,6 +97,24 @@ def test_init_camera_resolution():
         DEFAULT_FLIP_HORIZONTALLY,
         DEFAULT_FLIP_VERTICALLY
     )
+
+
+def test_raise_error_when_width_greater_than_maximum():
+    from spyglass import cli
+    # import spyglass.camera
+    with pytest.raises(argparse.ArgumentTypeError):
+        cli.main(args=[
+            '-r', '1921x1920'
+        ])
+
+
+def test_raise_error_when_height_greater_than_maximum():
+    from spyglass import cli
+    # import spyglass.camera
+    with pytest.raises(argparse.ArgumentTypeError):
+        cli.main(args=[
+            '-r', '1920x1921'
+        ])
 
 
 def test_init_camera_fps():
@@ -279,3 +298,4 @@ def test_run_server_with_configuration_from_arguments():
         '-sn', 'snapshot-url'
     ])
     spyglass.server.run_server.assert_called_once_with('1.2.3.4', 1234, ANY, 'streaming-url', 'snapshot-url')
+


### PR DESCRIPTION
The maximum resulution that is currently supported by picamera is 1920x1920. This pull request restricts the resolution to this maximum