### PR TITLE
fix: fix issue with python2

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 from spyglass.cli import main
 


### PR DESCRIPTION
This PR fixes the issue that run.py is accidently selecting python2 if it's installed.

Signed-off-by: Patrick Gehrsitz <58853838+mryel00@users.noreply.github.com>